### PR TITLE
feat: add config.puppeteerOpts

### DIFF
--- a/lib/proton-mail.js
+++ b/lib/proton-mail.js
@@ -23,6 +23,7 @@ class ProtonMail {
    * @param {Object} config
    * @param {Object} config.username Required, can be ProtonMail username or email
    * @param {Object} config.password Required
+   * @param {Object} config.puppeteerOpts puppeteer launch options
    * @return {ProtonMail}
    */
   static async connect (config) {
@@ -33,6 +34,7 @@ class ProtonMail {
 
   constructor (config) {
     this._config = config
+    this._config.puppeteerOpts = config.puppeteerOpts || {}
 
     if (!config.username) {
       throw new Error('config.username is required')
@@ -45,7 +47,7 @@ class ProtonMail {
 
   async _connect () {
     if (this._browser === undefined) {
-      this._browser = await puppeteer.launch({ headless: true })
+      this._browser = await puppeteer.launch({ headless: true, ...this._config.puppeteerOpts })
       this._page = await this._browser.newPage()
     }
 


### PR DESCRIPTION
Add `config.puppeteerOpts` to overwrite / extends puppeteer launch options.

Example, docker require `--no-sandbox` flag
```javascript
await Protonmail.connect({
  username: 'user',
  password: 'password',
  puppeteerOpts: {
     args: ['--no-sandbox']
  }
})
```